### PR TITLE
Use std duration, 2018 edition & modernize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "cache_control"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Conner Ebbinghaus <connerebbinghaus@gmail.com>"]
 description = "Rust crate to parse the HTTP Cache-Control header."
 license = "MIT"
 repository = "https://github.com/connerebbinghaus/rust-cache-control"
 readme = "README.md"
-
-[dependencies]
-time = "0.1"
+edition = "2018"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # rust-cache-control
 Rust crate to parse the HTTP Cache-Control header.
+
+```rust
+use cache_control::{Cachability, CacheControl};
+use std::time::Duration;
+
+let cache_control = CacheControl::from_header("Cache-Control: public, max-age=60").unwrap();
+assert_eq!(cache_control.cachability, Some(Cachability::Public));
+assert_eq!(cache_control.max_age, Some(Duration::from_secs(60)));
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,15 @@
-extern crate time;
+//! Rust crate to parse the HTTP Cache-Control header.
+//! # Example
+//! ```
+//! use cache_control::{Cachability, CacheControl};
+//! use std::time::Duration;
+//!
+//! let cache_control = CacheControl::from_header("Cache-Control: public, max-age=60").unwrap();
+//! assert_eq!(cache_control.cachability, Some(Cachability::Public));
+//! assert_eq!(cache_control.max_age, Some(Duration::from_secs(60)));
+//! ```
 
-use time::Duration;
+use core::time::Duration;
 
 /// How the data may be cached.
 #[derive(Eq, PartialEq, Debug)]
@@ -19,82 +28,70 @@ pub enum Cachability {
 }
 
 /// Represents a Cache-Control header
-/// # Example
-/// ```
-/// extern crate cache_control;
-/// extern crate time;
-/// use cache_control::CacheControl;
-/// use time::Duration;
-///
-/// let cache_control = CacheControl::from_header("Cache-Control: max-age=60").unwrap();
-/// assert_eq!(cache_control.max_age, Some(Duration::seconds(60)));
-/// ```
-///
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Default)]
 pub struct CacheControl {
     pub cachability: Option<Cachability>,
+    /// The maximum amount of time a resource is considered fresh.
+    /// Unlike `Expires`, this directive is relative to the time of the request.
     pub max_age: Option<Duration>,
+    /// Overrides max-age or the `Expires` header, but only for shared caches (e.g., proxies).
+    /// Ignored by private caches.
     pub s_max_age: Option<Duration>,
+    /// Indicates the client will accept a stale response. An optional value in seconds
+    /// indicates the upper limit of staleness the client will accept.
     pub max_stale: Option<Duration>,
+    /// Indicates the client wants a response that will still be fresh for at least
+    /// the specified number of seconds.
     pub min_fresh: Option<Duration>,
+    /// Indicates that once a resource becomes stale, caches do not use their stale
+    /// copy without successful validation on the origin server.
     pub must_revalidate: bool,
+    /// Like `must-revalidate`, but only for shared caches (e.g., proxies).
+    /// Ignored by private caches.
     pub proxy_revalidate: bool,
+    /// Indicates that the response body **will not change** over time.
     pub immutable: bool,
+    /// The response may not be stored in _any_ cache.
     pub no_store: bool,
+    /// An intermediate cache or proxy cannot edit the response body, 
+    /// `Content-Encoding`, `Content-Range`, or `Content-Type`.
     pub no_transform: bool,
 }
 
 impl CacheControl {
-    fn new() -> CacheControl {
-        CacheControl::default()
-    }
-
     /// Parses the value of the Cache-Control header (i.e. everything after "Cache-Control:").
-    pub fn from_value(value: &str) -> Option<CacheControl> {
-        let mut ret = CacheControl::new();
-        let tokens: Vec<&str> = value.split(",").collect();
-        for token in tokens {
-            let key_value: Vec<&str> = token.split("=").map(|s| s.trim()).collect();
-            let key = key_value.first().unwrap();
-            let val = key_value.get(1);
+    /// ```
+    /// use cache_control::{Cachability, CacheControl};
+    /// use std::time::Duration;
+    ///
+    /// let cache_control = CacheControl::from_value("public, max-age=60").unwrap();
+    /// assert_eq!(cache_control.cachability, Some(Cachability::Public));
+    /// assert_eq!(cache_control.max_age, Some(Duration::from_secs(60)));
+    /// ```
+    pub fn from_value(value: &str) -> Option<Self> {
+        let mut ret = Self::default();
+        for token in value.split(',') {
+            let (key, val) = {
+                let mut split = token.split('=').map(|s| s.trim());
+                (split.next().unwrap(), split.next())
+            };
 
-            match *key {
+            match key {
                 "public" => ret.cachability = Some(Cachability::Public),
                 "private" => ret.cachability = Some(Cachability::Private),
                 "no-cache" => ret.cachability = Some(Cachability::NoCache),
                 "only-if-cached" => ret.cachability = Some(Cachability::OnlyIfCached),
-                "max-age" => {
-                    if let None = val {
-                        return None;
-                    }
-                    let val_d = *(val.unwrap());
-                    let p_val = val_d.parse();
-                    if let Err(_) = p_val {
-                        return None;
-                    }
-                    ret.max_age = Some(Duration::seconds(p_val.unwrap()));
+                "max-age" => match val.and_then(|v| v.parse().ok()) {
+                    Some(secs) => ret.max_age = Some(Duration::from_secs(secs)),
+                    None => return None,
                 },
-                "max-stale" => {
-                    if let None = val {
-                        return None;
-                    }
-                    let val_d = *(val.unwrap());
-                    let p_val = val_d.parse();
-                    if let Err(_) = p_val {
-                        return None;
-                    }
-                    ret.max_stale = Some(Duration::seconds(p_val.unwrap()));
+                "max-stale" => match val.and_then(|v| v.parse().ok()) {
+                    Some(secs) => ret.max_stale = Some(Duration::from_secs(secs)),
+                    None => return None,
                 },
-                "min-fresh" => {
-                    if let None = val {
-                        return None;
-                    }
-                    let val_d = *(val.unwrap());
-                    let p_val = val_d.parse();
-                    if let Err(_) = p_val {
-                        return None;
-                    }
-                    ret.min_fresh = Some(Duration::seconds(p_val.unwrap()));
+                "min-fresh" => match val.and_then(|v| v.parse().ok()) {
+                    Some(secs) => ret.min_fresh = Some(Duration::from_secs(secs)),
+                    None => return None,
                 },
                 "must-revalidate" => ret.must_revalidate = true,
                 "proxy-revalidate" => ret.proxy_revalidate = true,
@@ -108,70 +105,84 @@ impl CacheControl {
     }
 
     /// Parses a Cache-Control header.
-    pub fn from_header(value: &str) -> Option<CacheControl> {
-        let header_value: Vec<&str> = value.split(":").map(|s| s.trim()).collect();
-        if header_value.len() != 2 || header_value.first().unwrap() != &"Cache-Control" {
+    pub fn from_header(value: &str) -> Option<Self> {
+        let (name, value) = value.split_once(':')?;
+        if !name.trim().eq_ignore_ascii_case("Cache-Control") {
             return None;
         }
-        let val = header_value.get(1).unwrap();
-        CacheControl::from_value(val)
-    }
-}
-
-impl Default for CacheControl {
-    fn default() -> Self {
-        CacheControl {
-            cachability: None,
-            max_age: None,
-            s_max_age: None,
-            max_stale: None,
-            min_fresh: None,
-            must_revalidate: false,
-            proxy_revalidate: false,
-            immutable: false,
-            no_store: false,
-            no_transform: false,
-        }
+        Self::from_value(value)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::{CacheControl, Cachability};
-    use time::Duration;
+    use super::*;
 
     #[test]
     fn test_from_value() {
-        assert_eq!(CacheControl::from_value("").unwrap(), CacheControl::default());
-        assert_eq!(CacheControl::from_value("private").unwrap().cachability.unwrap(), Cachability::Private);
-        assert_eq!(CacheControl::from_value("max-age=60").unwrap().max_age.unwrap(), Duration::seconds(60));
+        assert_eq!(
+            CacheControl::from_value("").unwrap(),
+            CacheControl::default()
+        );
+        assert_eq!(
+            CacheControl::from_value("private")
+                .unwrap()
+                .cachability
+                .unwrap(),
+            Cachability::Private
+        );
+        assert_eq!(
+            CacheControl::from_value("max-age=60")
+                .unwrap()
+                .max_age
+                .unwrap(),
+            Duration::from_secs(60)
+        );
     }
 
     #[test]
     fn test_from_value_multi() {
         let test1 = &CacheControl::from_value("no-cache, no-store, must-revalidate").unwrap();
         assert_eq!(test1.cachability, Some(Cachability::NoCache));
-        assert_eq!(test1.no_store, true);
-        assert_eq!(test1.must_revalidate, true);
-        assert_eq!(*test1, CacheControl {
-            cachability: Some(Cachability::NoCache),
-            max_age: None,
-            s_max_age: None,
-            max_stale: None,
-            min_fresh: None,
-            must_revalidate: true,
-            proxy_revalidate: false,
-            immutable: false,
-            no_store: true,
-            no_transform: false,
-        });
+        assert!(test1.no_store);
+        assert!(test1.must_revalidate);
+        assert_eq!(
+            *test1,
+            CacheControl {
+                cachability: Some(Cachability::NoCache),
+                max_age: None,
+                s_max_age: None,
+                max_stale: None,
+                min_fresh: None,
+                must_revalidate: true,
+                proxy_revalidate: false,
+                immutable: false,
+                no_store: true,
+                no_transform: false,
+            }
+        );
     }
 
     #[test]
     fn test_from_header() {
-        assert_eq!(CacheControl::from_header("Cache-Control: ").unwrap(), CacheControl::default());
-        assert_eq!(CacheControl::from_header("Cache-Control: private").unwrap().cachability.unwrap(), Cachability::Private);
-        assert_eq!(CacheControl::from_header("Cache-Control: max-age=60").unwrap().max_age.unwrap(), Duration::seconds(60));
+        assert_eq!(
+            CacheControl::from_header("Cache-Control: ").unwrap(),
+            CacheControl::default()
+        );
+        assert_eq!(
+            CacheControl::from_header("Cache-Control: private")
+                .unwrap()
+                .cachability
+                .unwrap(),
+            Cachability::Private
+        );
+        assert_eq!(
+            CacheControl::from_header("Cache-Control: max-age=60")
+                .unwrap()
+                .max_age
+                .unwrap(),
+            Duration::from_secs(60)
+        );
         assert_eq!(CacheControl::from_header("foo"), None);
         assert_eq!(CacheControl::from_header("bar: max-age=60"), None);
     }
@@ -180,18 +191,21 @@ mod test {
     fn test_from_header_multi() {
         let test1 = &CacheControl::from_header("Cache-Control: public, max-age=600").unwrap();
         assert_eq!(test1.cachability, Some(Cachability::Public));
-        assert_eq!(test1.max_age, Some(Duration::seconds(600)));
-        assert_eq!(*test1, CacheControl {
-            cachability: Some(Cachability::Public),
-            max_age: Some(Duration::seconds(600)),
-            s_max_age: None,
-            max_stale: None,
-            min_fresh: None,
-            must_revalidate: false,
-            proxy_revalidate: false,
-            immutable: false,
-            no_store: false,
-            no_transform: false,
-        });
+        assert_eq!(test1.max_age, Some(Duration::from_secs(600)));
+        assert_eq!(
+            *test1,
+            CacheControl {
+                cachability: Some(Cachability::Public),
+                max_age: Some(Duration::from_secs(600)),
+                s_max_age: None,
+                max_stale: None,
+                min_fresh: None,
+                must_revalidate: false,
+                proxy_revalidate: false,
+                immutable: false,
+                no_store: false,
+                no_transform: false,
+            }
+        );
     }
 }


### PR DESCRIPTION
* Remove dependency _time_ instead use `std::time::Duration`. Std duration are unsigned, however we expect cache-control duration also to be unsigned.
* Use 2018 edition.
* Modernize code.
* `cargo fmt`
* Add documentation & readme example.
* Up version to `0.2`, a breaking change because of the new `Duration` usage.