### PR TITLE
fix: add support for "s-maxage" directive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,10 @@ impl CacheControl {
                     Some(secs) => ret.max_age = Some(Duration::from_secs(secs)),
                     None => return None,
                 },
+                "s-maxage" => match val.and_then(|v| v.parse().ok()) {
+                    Some(secs) => ret.s_max_age = Some(Duration::from_secs(secs)),
+                    None => return None,
+                },
                 "max-stale" => match val.and_then(|v| v.parse().ok()) {
                     Some(secs) => ret.max_stale = Some(Duration::from_secs(secs)),
                     None => return None,


### PR DESCRIPTION
I found that although there is a `s_max_age` property of the `CacheControl` struct, the function that parses the value of `Cache-Control` header doesn't properly obtain the value of `s-maxage` property, so I added the condition for the `s-maxage` property in `Cache-Control` header.